### PR TITLE
Implemented: support to store user preference for selected brands (#2f2h93z)

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -32,9 +32,28 @@ const setUserTimeZone = async (payload: any): Promise <any>  => {
   });
 }
 
+const setUserPreference = async (payload: any): Promise<any> => {
+  return api({
+    url: "service/setUserPreference",
+    method: "post",
+    data: payload
+  });
+}
+
+const getUserPreference = async (payload: any): Promise<any> => {
+  return api({
+    url: "service/getUserPreference",
+    //TODO Due to security reasons service model OMS 1.0 does not support sending parameters in get request that's why we use post here
+    method: "post",
+    data: payload
+  });
+}
+
 export const UserService = {
     login,
     getAvailableTimeZones,
     getProfile,
     setUserTimeZone,
+    setUserPreference,
+    getUserPreference
 }

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -55,6 +55,12 @@ const actions: ActionTree<UserState, RootState> = {
   async getProfile ( { commit }) {
     const resp = await UserService.getProfile()
     if (resp.status === 200) {
+      const userPref =  await UserService.getUserPreference({
+        'userPrefTypeId': 'SELECTED_BRAND'
+      });
+      const brands = JSON.parse(process.env.VUE_APP_BRANDS)
+      const userPrefBrand = brands.find((brand: any) => brand.id == userPref.data.userPrefValue)
+      commit(types.USER_BRAND_UPDATED, userPrefBrand ? userPrefBrand.id: brands ? brands[0].id : {})
       commit(types.USER_INFO_UPDATED, resp.data);
     }
   },
@@ -80,6 +86,10 @@ const actions: ActionTree<UserState, RootState> = {
       // Reset all the current queries
       this.dispatch("product/resetProductList")
       this.dispatch("order/resetOrderQuery")
+      await UserService.setUserPreference({
+        'userPrefTypeId': 'SELECTED_BRAND',
+        'userPrefValue': payload.selectedBrand
+      });
     },
 
   /**


### PR DESCRIPTION
### Related Issues
Added support to store user preference for selected brands 
- make new services setUserPref  for set the selected brand preference  and getUserPref for getting the current preferenced brand
- set User preference while selecting of brand and get User preference during login

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)