### PR TITLE
Fixed eCommerce options are not visible on settings page (#85zrhj216)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -95,6 +95,14 @@ const actions: ActionTree<UserState, RootState> = {
       let stores = [] as any;
       if(storeResp.status === 200 && !hasError(storeResp) && storeResp.data.docs?.length > 0) {
         stores = [...storeResp.data.docs]
+        
+        resp.data.stores = [
+          ...(stores ? stores : []),
+          {
+            productStoreId: "",
+            storeName: "None"
+          }
+        ]
       }
 
       let userPrefStore = ''

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -80,6 +80,8 @@ const actions: ActionTree<UserState, RootState> = {
    */
   async getProfile ( { commit, dispatch }) {
     const resp = await UserService.getProfile()
+    const userProfile = JSON.parse(JSON.stringify(resp.data));
+
     if (resp.status === 200) {
       const payload = {
         "inputFields": {
@@ -96,11 +98,14 @@ const actions: ActionTree<UserState, RootState> = {
       if(storeResp.status === 200 && !hasError(storeResp) && storeResp.data.docs?.length > 0) {
         stores = [...storeResp.data.docs]
         
-        resp.data.stores = [
-          ...(stores ? stores : []),
+        userProfile.stores = [
+          ...stores,
           {
+            // With the preorder app's use case, the user will get data specific to the product store
+            // or all the data, for instance, on the products page. either products belonging to the 
+            // selected store are fetched or all the products are fetched.
             productStoreId: "",
-            storeName: "None"
+            storeName: "All"
           }
         ]
       }
@@ -116,7 +121,7 @@ const actions: ActionTree<UserState, RootState> = {
         console.error(err)
       }
       dispatch('setEcomStore', { eComStore: userPrefStore ? userPrefStore : stores.length > 0 ? stores[0] : {} });
-      commit(types.USER_INFO_UPDATED, resp.data);
+      commit(types.USER_INFO_UPDATED, userProfile);
     }
   },
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #95 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed eCommerce store options not appearing on the settings page. 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
#### Before
![Preorder Management - HotWax Commerce](https://user-images.githubusercontent.com/59442907/211260264-01e27432-2e63-4929-ae73-9148eb6bac2d.png)
#### After
![Preorder Management - HotWax Commerce (1)](https://user-images.githubusercontent.com/59442907/211260253-252c8a50-2fc9-4537-944f-b3b50669b0ff.png)


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)