### PR TITLE
Fixed: Incorrect Total PO Items, wrong Current Sales Order data and missing parent product name (149) (143) (141)

### DIFF
--- a/src/views/catalog-product-details.vue
+++ b/src/views/catalog-product-details.vue
@@ -17,7 +17,7 @@
 
         <div class="product-info" v-if="Object.keys(currentVariant).length">
           <div class="ion-padding">
-            <h4>{{ currentVariant.productName }}</h4>
+            <h4>{{ currentVariant.parentProductName }}</h4>
             <p>{{ currentVariant.sku }}</p>
           </div>
 
@@ -609,7 +609,9 @@ export default defineComponent({
             "orderStatusId_op": "in",
             "itemStatusId": ["ITEM_CREATED", "ITEM_APPROVED"],
             "itemStatusId_op": "in",
-            "estimatedDeliveryDate_op": "greaterThanFromDayStart"
+            "estimatedDeliveryDate_op": "greaterThanFromDayStart",
+            "orderTypeId": "PURCHASE_ORDER",
+            "orderTypeId_op": "equals"
           },
           "entityName": "OrderHeaderAndItems",
           "viewSize": 1
@@ -621,9 +623,9 @@ export default defineComponent({
           payload = {
             "json": {
               "params": {
-                "rows": 0,
+                "rows": 1,
               },
-              "filter": `docType: ORDER AND orderTypeId: SALES_ORDER AND productStoreId: ${this.currentEComStore.productStoreId} AND correspondingPoId: ${this.poAndAtpDetails.activePoId ? this.poAndAtpDetails.activePoId : this.poAndAtpDetails.lastActivePoId}`,
+              "filter": `docType: ORDER AND orderTypeId: SALES_ORDER AND productId: ${variantId} AND productStoreId: ${this.currentEComStore.productStoreId} AND correspondingPoId: ${this.poAndAtpDetails.activePoId ? this.poAndAtpDetails.activePoId : this.poAndAtpDetails.lastActivePoId}`,
               "query": "*:*",
             }
           }


### PR DESCRIPTION


The Purchase Order card is displaying the wrong corresponding sales order data for the Purchase order. It is counting the total number of sales orders associated with the purchase order.

The Total PO items displayed in the Purchase Order card includes both Sales orders and Purchase orders, resulting in an incorrect net total.

The products on the Catalog page only display their variant names, which makes it difficult to identify them without their parent product names.

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #149
Closes #143 
Closes #141 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)