### PR TITLE
Fixed: Inconsistent Header in Purchase Order Card (#147)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -116,7 +116,7 @@
     "Pieces": "Pieces",
     "pieces preordered": "pieces preordered",
     "PO": "PO",
-    "PO #": "PO # {pOId}",
+    "PO #": "PO #{pOId}",
     "PO ATP": "PO ATP",
     "preorder": "preorder",
     "pre-order": "pre-order",


### PR DESCRIPTION
Used only ProductCategoryDcsnRsn for getting the active PO, based upon the categoryId labeled it as current or last active PO

Fixed logic to get preorder items using orderId
Improved UI to handle when there are no active or last active PO

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #147 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)