### PR TITLE
Implemented: Page Selection Persistence for Preorder App  with Side Navigation (#122)

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -77,12 +77,14 @@ export default defineComponent({
       {
         title: "Products",
         url: "/products",
+        childRoutes: ["/product-details/"],
         iosIcon: shirt,
         mdIcon: shirt,
       },
       {
         title: "Catalog",
         url: "/catalog",
+        childRoutes: ["/catalog-product-details/"],
         iosIcon: albums,
         mdIcon: albums,
       },
@@ -92,11 +94,11 @@ export default defineComponent({
         iosIcon: settings,
         mdIcon: settings,
       }
-    ] as any;
+    ];
 
     const selectedIndex = computed(() => {
       const path = router.currentRoute.value.path
-      return appPages.findIndex((screen : any) => screen.url === path || screen.childRoutes?.includes(path))
+      return appPages.findIndex((screen) => screen.url === path || screen.childRoutes?.includes(path) || screen.childRoutes?.some((route)=> path.includes(route)))
     })
 
 

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -11,7 +11,6 @@
             <ion-menu-toggle auto-hide="false" v-for="(p, i) in appPages" :key="i">
               <ion-item
                 button
-                @click="selectedIndex = i"
                 router-direction="root"
                 :router-link="p.url"
                 class="hydrated"
@@ -39,11 +38,12 @@ import {
   IonMenu,
   IonMenuToggle,
 } from "@ionic/vue";
-import { defineComponent, ref } from "vue";
+import { computed, defineComponent} from "vue"
 import { mapGetters } from "vuex";
 
 import { albums ,shirt, pricetags, settings } from "ionicons/icons";
 import { useStore } from "@/store";
+import { useRouter } from "vue-router";
 
 export default defineComponent({
   name: "Menu",
@@ -59,30 +59,14 @@ export default defineComponent({
     IonMenu,
     IonMenuToggle,
   },
-  created() {
-    // When open any specific page it should show that page selected
-    // TODO Find a better way
-    this.selectedIndex = this.appPages.findIndex((page) => {
-      return page.url === this.$router.currentRoute.value.path;
-    })
-  },
   computed: {
     ...mapGetters({
       isUserAuthenticated: 'user/isUserAuthenticated'
     })
   },
-  watch:{
-    $route (to) {
-      // When logout and login it should point to Oth index
-      // TODO Find a better way
-      if (to.path === '/login') {
-        this.selectedIndex = 0;
-      }
-    },
-  }, 
   setup() {
     const store = useStore();
-    const selectedIndex = ref(0);
+    const router = useRouter();
     const appPages = [
       {
         title: "Orders",
@@ -107,8 +91,15 @@ export default defineComponent({
         url: "/settings",
         iosIcon: settings,
         mdIcon: settings,
-      },
-    ];
+      }
+    ] as any;
+
+    const selectedIndex = computed(() => {
+      const path = router.currentRoute.value.path
+      return appPages.findIndex((screen : any) => screen.url === path || screen.childRoutes?.includes(path))
+    })
+
+
     return {
       selectedIndex,
       appPages,
@@ -118,7 +109,7 @@ export default defineComponent({
       settings,
       store
     };
-  },
+  }
 });
 </script>
 <style scoped>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Issue link: https://github.com/hotwax/dxp-components/issues/122

### Short Description and Why It's Useful
Fixed the issue of menu not being enabled for the correct page when using the back button in the preorder app.
- Removed a watcher from the menu component that checks for route changes
- Defined a computed property to find the correct index in the menu list
- Added an entry in the menu component pages to list all the child routes those are not listed in the menu for a specific parent route, using which we have enabled the correct menu in the UI.
- Added a logic for the dynamic child routes in the app.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)