### PR TITLE
Improved: renamed the catalog's product detail page title (#187)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -144,7 +144,7 @@
     "preorder items will be released to the warehouse you have selected.": "{count} preorder items will be released to the warehouse you have selected.",
     "preorders will be cancelled. This action cannot be undone.": "{count} preorders will be cancelled. This action cannot be undone.",
     "Products": "Products",
-    "Product details": "Product details",
+    "Product summary page": "Product summary page",
     "Product cannot be pre-sold because it does not have active purchase orders": "Product cannot be pre-sold because it does not have active purchase orders",
     "Product has been accepting from against PO #": "Product has been accepting {category}s from {fromDate} against PO #${POID}",
     "Product is eligible for but not added to the category": "Product is eligible for {category}s but not added to the {category} category",

--- a/src/views/catalog-product-details.vue
+++ b/src/views/catalog-product-details.vue
@@ -5,7 +5,7 @@
         <ion-buttons slot="start">
           <ion-back-button default-href="/catalog"></ion-back-button>
         </ion-buttons>
-        <ion-title>{{ $t("Product details") }}</ion-title>
+        <ion-title>{{ $t("Product summary page") }}</ion-title>
       </ion-toolbar>
     </ion-header>
     <ion-content>


### PR DESCRIPTION
### Related Issues
Closes #187

### Short Description and Why It's Useful
Changed the title of the catalog's product detail page form "Product details" to "Product summary page".


### Screenshots of Visual Changes before/after (If There Are Any)
Before
![Screenshot from 2023-08-18 11-15-02](https://github.com/hotwax/preorder/assets/69574321/31cd2a37-0d6d-4c99-8737-d79fbe00295f)

After
![Screenshot from 2023-08-18 11-14-47](https://github.com/hotwax/preorder/assets/69574321/efa80ab4-902b-4cd2-9e62-b1db4910d355)




**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)