### PR TITLE
Fixed: eliminated 'in' word duplication in timeline message on product summary page (#211)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -4,7 +4,7 @@
     "Active jobs": "Active jobs",
     "Active purchase order": "Active purchase order",
     "Added to pre-order category on, against PO but not listed on all stores" : "Added to pre-order category on {fromDate}, against PO #{POID} but not listed on all stores",
-    "Adding to in": "Adding to {categoryName} in {addingTime}",
+    "Adding to": "Adding to {categoryName} {addingTime}",
     "All": "All",
     "App": "App",
     "Are you sure you want to update the promise date for these orders?": "Are you sure you want to update the promise date for these orders?",

--- a/src/views/catalog-product-details.vue
+++ b/src/views/catalog-product-details.vue
@@ -872,7 +872,7 @@ export default defineComponent({
         if (Object.keys(presellingJob).length === 0 || !presellingJob.runTime) {
           this.poSummary.header = this.$t("Pre-sell processing disabled");
         } else {
-          this.poSummary.header = this.$t("Adding to in", { categoryName, addingTime: this.timeTillJob(presellingJob.runTime) });
+          this.poSummary.header = this.$t("Adding to", { categoryName, addingTime: this.timeTillJob(presellingJob.runTime) });
         }
         this.poSummary.body = this.$t("This product will begin pre-selling because it is out of stock and purchase order is available.", { poId: this.poAndAtpDetails.activePo.orderExternalId ? this.poAndAtpDetails.activePo.orderExternalId : this.poAndAtpDetails.activePo.orderId });
       } else if (!this.poSummary.eligible && hasCategory) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #211

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removed 'in' from timeline message to avoid word duplication on product summary page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)