### PR TITLE
Fixed: shopify listing to display status when listing is done directly or by third party(#198)

### DIFF
--- a/src/views/catalog-product-details.vue
+++ b/src/views/catalog-product-details.vue
@@ -988,6 +988,7 @@ export default defineComponent({
         const shopifyConfigsAndProductIds = this.configsByStores.reduce((shopifyConfigsAndProductIds: any, config: any) => {
           const shopifyShop = shopifyConfigsAndProductIds[config.shopId] || {}
           !shopifyShop.variantProductId && (shopifyShop.variantProductId = this.getProductIdentificationId(this.currentVariant.goodIdentifications, 'ShopifyShopProduct/' + config.shopId))
+          !shopifyShop.hcVariantProductId && (shopifyShop.hcVariantProductId = this.currentVariant.productId)
           shopifyConfigsAndProductIds[config.shopId] = shopifyShop;
           configs[config.shopId] = config;
           return shopifyConfigsAndProductIds
@@ -998,7 +999,7 @@ export default defineComponent({
           let listData = {
             ...configs[shopId], // adding shopify shop information to be available for showing name
           } as any
-          if (!configAndIdData.variantProductId) {
+          if (!configAndIdData.variantProductId && !configAndIdData.hcVariantProductId) {
             this.shopListings = [...this.shopListings, listData]
             // TODO Find a better way
             return Promise.resolve(this.shopListings)
@@ -1012,7 +1013,7 @@ export default defineComponent({
               } as any,
               "filter": `docType: BULKOPERATION
                   AND operation: 'SHOP_PREORDER_SYNC'
-                  AND data_productVariantUpdate_productVariant_id: "gid://shopify/ProductVariant/${configAndIdData.variantProductId}"
+                  AND data_productVariantUpdate_productVariant_id: ("gid://shopify/ProductVariant/${configAndIdData.variantProductId}" OR "gid://hotwax/ProductVariant/id/${configAndIdData.hcVariantProductId}")
                   AND data_productVariantUpdate_productVariant_metafields_edges_node_namespace: "HC_PREORDER"`,
               "query": "*:*",
             },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #198

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Previously, when fetching the shopify listing status, we were always fetching the status using shopify Id, but in some cases we list the product using third party that makes the use of HotWax product Id. So in any of the case, we should always get the status.
Added support to fetch the listing data on both shopify product id and HotWax product id.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)