### PR TITLE
Fixed: incorrect sizing sequence order by adding sorting support for point value size values in apparel sorter and showed active PO quantity instead of total ATP in timeline message (#216)

### DIFF
--- a/src/apparel-sorter/index.ts
+++ b/src/apparel-sorter/index.ts
@@ -139,6 +139,16 @@ export function sortSizes(sizes: any) {
   if (!sizes) {
     return [];
   }
+
+  const hasFloatNumSizes = sizes.some((size: string) => {
+    const sizeAsInt = +size
+    return (!Number.isNaN(sizeAsInt) && !Number.isInteger(sizeAsInt))
+  })
+
+  if (hasFloatNumSizes) {
+    sizes.sort((a: string, b: string) => (+a) - (+b))
+  }
+
   return sizes
     .map(matchSizesWithRegexes)
     .sort(sortSizesByIndex)

--- a/src/apparel-sorter/index.ts
+++ b/src/apparel-sorter/index.ts
@@ -146,7 +146,7 @@ export function sortSizes(sizes: any) {
   })
 
   if (hasFloatNumSizes) {
-    sizes.sort((a: string, b: string) => (+a) - (+b))
+    return sizes.sort((a: string, b: string) => (+a) - (+b))
   }
 
   return sizes

--- a/src/views/catalog-product-details.vue
+++ b/src/views/catalog-product-details.vue
@@ -853,7 +853,7 @@ export default defineComponent({
         } else {
           this.poSummary.header = this.$t("Added to", { categoryName });
         }
-        this.poSummary.body = this.$t("When this product entered there was no sellable inventory and was available in", { categoryName, poItemATP: this.poAndAtpDetails.totalPoAtp , poId: this.poAndAtpDetails.activePo.orderExternalId ? this.poAndAtpDetails.activePo.orderExternalId : this.poAndAtpDetails.activePo.orderId  });
+        this.poSummary.body = this.$t("When this product entered there was no sellable inventory and was available in", { categoryName, poItemATP: this.poAndAtpDetails.activePo.quantity , poId: this.poAndAtpDetails.activePo.orderExternalId ? this.poAndAtpDetails.activePo.orderExternalId : this.poAndAtpDetails.activePo.orderId  });
       } else if (!this.poSummary.eligible && !hasCategory) {
         const presellingJob = this.getCtgryAndBrkrngJob('JOB_REL_PREODR_CAT');
         if (Object.keys(presellingJob).length === 0 || !presellingJob.runTime) {

--- a/src/views/catalog.vue
+++ b/src/views/catalog.vue
@@ -165,9 +165,9 @@ export default defineComponent({
       isCatalogScrollable: 'product/isCatalogScrollable'
     })
   },
-  mounted() {
-    this.getCatalogProducts()
-    this.preparePreordBckordComputationJob()
+  async ionViewWillEnter() {
+    await this.getCatalogProducts()
+    await this.preparePreordBckordComputationJob()
   },
   methods: {
     async getCatalogProducts(vSize?: any, vIndex?: any) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #216 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixes/improvements - 
- Fixed incorrect sizing sequence order by adding sorting support for point value size values in the apparel sorter.
- Showed active PO quantity instead of total ATP in the timeline message.
- Improved code to fetch products and job data on catalog page through ionic view and async handling.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![size sorted](https://github.com/hotwax/preorder/assets/59442907/29f210f8-f12e-4e7b-a5c2-5472d160428b)


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)