### PR TITLE
Fixed: listing data not visible when listingTime information is missing(#225)

### DIFF
--- a/src/views/catalog-product-details.vue
+++ b/src/views/catalog-product-details.vue
@@ -1059,24 +1059,27 @@ export default defineComponent({
               status: metafieldValue.status,
               promiseDate: metafieldValue["promise_date"]
             }
-            const listingTime = DateTime.fromFormat(listData.listingTime, "MMM dd,yyyy HH:mm:ss").toLocaleString(DateTime.DATETIME_MED);
+            let listingTime = ''
+            if(listData.listingTime) {
+              listingTime = DateTime.fromFormat(listData.listingTime, "MMM dd,yyyy HH:mm:ss").toLocaleString(DateTime.DATETIME_MED);
+            }
             if (!listData.containsError) {
               if (listData.status === 'inactive') {
-                // showing the job's runTime as listing time
-                listData.listingTimeAndStatus = this.$t("Delisted at", { listingTime })
+                // showing the job's runTime as listing time, and not showing listing time if not present
+                listingTime && (listData.listingTimeAndStatus = this.$t("Delisted at", { listingTime }))
                 listData.listingStatus = 'Not listed'
               } else {
-                listData.listingTimeAndStatus = this.$t("Listed at", { listingTime })
+                listingTime && (listData.listingTimeAndStatus = this.$t("Listed at", { listingTime }))
                 listData.listingStatus = 'Listed'
               }
             } else {
               // If it failed to update, considered the status must old
               if (listData.status === 'inactive') {
                 // showing the job's runTime as listing time
-                listData.listingTimeAndStatus = this.$t("Delisting failed at", { listingTime })
+                listingTime && (listData.listingTimeAndStatus = this.$t("Delisting failed at", { listingTime }))
                 listData.listingStatus = 'Listed'
               } else {
-                listData.listingTimeAndStatus = this.$t("Listing failed at", { listingTime })
+                listingTime && (listData.listingTimeAndStatus = this.$t("Listing failed at", { listingTime }))
                 listData.listingStatus = 'Not listed'
               }
             }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #225

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In some cases, we are having listing information available, but the information has missing listingTime due to which the code breaks.
So, added a check for listingTime, and show the time on UI only when the time is available


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)