### PR TITLE
Fixed: the active PO information on the catalog details page

### DIFF
--- a/src/views/catalog-product-details.vue
+++ b/src/views/catalog-product-details.vue
@@ -617,7 +617,7 @@ export default defineComponent({
             "entityName": "ProductCategoryDcsnRsn",
             "fieldList": ["productId", "purchaseOrderId", "fromDate"],
             "viewSize": 1,
-            "orderBy": "createdDate DESC"
+            "orderBy": "estimatedDeliveryDate ASC"
           } as any;
           resp = await OrderService.getActivePoId(payload)
           if (!hasError(resp)) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Wrong PO information is displayed on the active PO card on the catalog page

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Changed the orderBy field to use estimatedDeliveryDate to fetch the PO information.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)