### PR TITLE
Fixed: enhanced permission error messaging to include missing permission details and added locales (#305)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -239,6 +239,7 @@
     "Time zone updated successfully": "Time zone updated successfully",
     "Total PO ATP": "Total PO ATP",
     "Total PO items": "Total PO items",
+    "Unable to login. User is not associated with any product store.": "Unable to login. User is not associated with any product store.",
     "Update promise date": "Update promise date",
     "Update time zone": "Update time zone",
     "Username": "Username",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -249,5 +249,6 @@
     "With Hold Pre-order Queue Physical Inventory disabled, the excess inventory is now available for sale online after deducting the queues": "With Hold Pre-order Queue Physical Inventory disabled, the excess inventory is now available for sale online after deducting the queues",
     "Would you like to update your time zone to . Your profile is currently set to . This setting can always be changed from the settings menu.": "Would you like to update your time zone to {localTimeZone}. Your profile is currently set to {profileTimeZone}. This setting can always be changed from the settings menu.",
     "Yes": "Yes",
-    "You do not have permission to access this page": "You do not have permission to access this page"
+    "You do not have permission to access this page": "You do not have permission to access this page",
+    "You do not have permission to access the app. Missing permission: ": "You do not have permission to access the app. Missing permission: {permissionId}"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -251,5 +251,5 @@
     "Would you like to update your time zone to . Your profile is currently set to . This setting can always be changed from the settings menu.": "Would you like to update your time zone to {localTimeZone}. Your profile is currently set to {profileTimeZone}. This setting can always be changed from the settings menu.",
     "Yes": "Yes",
     "You do not have permission to access this page": "You do not have permission to access this page",
-    "You do not have permission to access the app. Missing permission: ": "You do not have permission to access the app. Missing permission: {permissionId}"
+    "You do not have permission to access the app.": "You do not have permission to access the app."
 }

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -42,7 +42,7 @@ const actions: ActionTree<UserState, RootState> = {
             const hasPermission = appPermissions.some((appPermission: any) => appPermission.action === permissionId );
             // If there are any errors or permission check fails do not allow user to login
             if (!hasPermission) {
-              const permissionError = `You do not have permission to access the app. Missing permission: ${permissionId}`;
+              const permissionError = "You do not have permission to access the app.";
               showToast(translate(permissionError));
               console.error("error", permissionError);
               return Promise.reject(new Error(permissionError));
@@ -51,9 +51,16 @@ const actions: ActionTree<UserState, RootState> = {
 
           const isAdminUser = appPermissions.some((appPermission: any) => appPermission?.action === "MERCHANDISING_ADMIN");
 
-          // Getting user profile
+          // Getting user profile & if user is not associated with any product store, then showing this error
           const userProfile = await UserService.getUserProfile(token);
-          userProfile.stores = await UserService.getEComStores(token, userProfile.partyId, isAdminUser);
+          try {
+            userProfile.stores = await UserService.getEComStores(token, userProfile.partyId, isAdminUser);
+          } catch (error) {
+            const reason = "Unable to login. User is not associated with any product store.";
+            console.error(reason, error);
+            showToast(translate(reason));
+            return Promise.reject(new Error(reason));
+          }
           
           // Getting user preferred store
           let preferredStore = userProfile.stores[0];

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -42,7 +42,7 @@ const actions: ActionTree<UserState, RootState> = {
             const hasPermission = appPermissions.some((appPermission: any) => appPermission.action === permissionId );
             // If there are any errors or permission check fails do not allow user to login
             if (!hasPermission) {
-              const permissionError = 'You do not have permission to access the app.';
+              const permissionError = `You do not have permission to access the app. Missing permission: ${permissionId}`;
               showToast(translate(permissionError));
               console.error("error", permissionError);
               return Promise.reject(new Error(permissionError));


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#305 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Enhanced permission error messaging to include missing permission details and added locales to resolve issue of error message shown is "Login failed. Please contact the administrator", which was misleading and does not accurately describe the issue.

the app now displays a clear and relevant error message indicating that the user does not have access due to the specific permission.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 07-03-25 06:22:23 PM IST.webm](https://github.com/user-attachments/assets/855d813c-97d8-4d39-80e5-59fba2bf2176)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/preorder#contribution-guideline)