### PR TITLE
Fixed: the alert box issue where it was not being removed after changes. (#328)

### DIFF
--- a/src/views/audit-product-details.vue
+++ b/src/views/audit-product-details.vue
@@ -809,6 +809,7 @@ export default defineComponent({
     },
     async updateReserveInvConfig(event: any) {
       // For preventing ion-toggle from toggling
+      event.preventDefault();
       event.stopImmediatePropagation();
 
       const isChecked = event.target.checked;
@@ -842,6 +843,7 @@ export default defineComponent({
     },
     async updatePreOrdPhyInvHoldConfig(event: any) {
       // For preventing ion-toggle from toggling
+      event.preventDefault();
       event.stopImmediatePropagation();
 
       const isChecked = event.target.checked;


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#328 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- The alert box now dismisses correctly after clicking the alert button.
- Added preventDefault on the event to stop the default toggle behavior of the ion-toggle.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/preorder#contribution-guideline)