### PR TITLE
Fixed: Incorrect format used for converting the order promised date (#326)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -214,7 +214,7 @@ const actions: ActionTree<OrderState, RootState> = {
         if (order) {
           const item = order.doclist.docs.find((orderItem: any) => orderItem.orderItemSeqId === payload.orderItemSeqId);
           // TODO Check if we can use the value from the response
-          item.promisedDatetime = DateTime.fromFormat(payload.promisedDatetime, "yyyy-MM-dd hh:mm:ss.SSS").toFormat("YYYY-MM-DD'T'hh:mm:ss'Z'");
+          item.promisedDatetime = DateTime.fromFormat(payload.promisedDatetime, "yyyy-MM-dd hh:mm:ss.SSS").toFormat("yyyy-MM-dd'T'hh:mm:ss'Z'");
         }
         commit(types.ORDER_LIST_UPDATED, state.list );
         showToast(translate("Item promise date updated successfully"));


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#326 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Fixed the issue where, while setting the promised date-time value to the order item, the conversion format was incorrect. As a result, the `formatUtcDate` utility function was returning "Invalid" instead of a valid date.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/c2ef5fec-16e8-400b-ab77-78bd79257443)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/preorder#contribution-guideline)