### PR TITLE
refactor: updated shop listing status message for products not linked to store.

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -168,6 +168,7 @@
     "Promise date": "Promise date",
     "Promised date": "Promised date",
     "Product not found": "Product not found",
+    "Product not sold on this shop": "Product not sold on this shop",
     "Purchase orders": "Purchase orders",
     "Quantity on hand": "Quantity on hand",
     "Related jobs": "Related jobs",

--- a/src/views/audit-product-details.vue
+++ b/src/views/audit-product-details.vue
@@ -341,7 +341,7 @@
                 <h5>{{ $t("No listing data") }}</h5>
               </ion-label>
               <ion-label v-else color="medium" slot="end">
-                <h5>{{ $t("Not linked") }}</h5>
+                <h5>{{ $t("Product not sold on this shop") }}</h5>
               </ion-label>
             </ion-item>
           </div>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Product not linked to Shopify Store #254

### Short Description and Why It's Useful
To show a relavant message if a product is not linked to specific store.

<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/preorder#contribution-guideline)