### PR TITLE
Fixed: Undefined field solr exception while fetching shopify listing data

### DIFF
--- a/src/views/audit-product-details.vue
+++ b/src/views/audit-product-details.vue
@@ -1088,7 +1088,7 @@ export default defineComponent({
                 "rows": 1,
                 "sort": "_timestamp_ desc",
               } as any,
-              "filter": `docType: BULKOPERATION AND operation: SHOP_PREORDER_SYNC AND data.productVariantsBulkUpdate.productVariants.id: (${configAndIdData.variantProductId && `"gid://shopify/ProductVariant/${configAndIdData.variantProductId}" OR`} "gid://hotwax/ProductVariant/id/${configAndIdData.hcVariantProductId}") AND data.productVariantsBulkUpdate.productVariants.metafields.edges.node.namespace: "HC_PREORDER"`,
+              "filter": `docType: BULKOPERATION AND operation: SHOP_PREORDER_SYNC AND (data.productVariantsBulkUpdate.productVariants.id: (${configAndIdData.variantProductId && `"gid://shopify/ProductVariant/${configAndIdData.variantProductId}" OR`} "gid://hotwax/ProductVariant/id/${configAndIdData.hcVariantProductId}") OR data_productVariantUpdate_productVariant_id: (${configAndIdData.variantProductId && `"gid://shopify/ProductVariant/${configAndIdData.variantProductId}" OR`} "gid://hotwax/ProductVariant/id/${configAndIdData.hcVariantProductId}")) AND (data.productVariantsBulkUpdate.productVariants.metafields.edges.node.namespace: "HC_PREORDER" OR data_productVariantUpdate_productVariant_metafields_edges_node_namespace: "HC_PREORDER")`,
               "query": "*:*",
             },
             "coreName": "shopifyCore"


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#254 
Related to issue #317

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
We are encountering the Solr exception due to discrepancies in the field names, mainly the fields that are used to filter the data in the Solr query.

Now I update the Solr query to add support for filtering with both of the fields

We have these two fields in the Solr document:
- `data.productVariantsBulkUpdate.productVariants.id`
- `data_productVariantUpdate_productVariant_id` (This field is marked for deprecation; we will not populating this field in future)

### NOTE
In the future, we need to remove the OR checks from the Solr query; we will only use the following fields
- `data.productVariantsBulkUpdate.productVariants.id`
- `data.productVariantsBulkUpdate.productVariants.metafields.edges.node.value`
- `data.productVariantsBulkUpdate.productVariants.metafields.edges.node.namespace`

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/preorder#contribution-guideline)