### PR TITLE
Fixed : Inconsistent Page Landing on the Audit Tab When Switching Tabs After Viewing Preorder or Backorder Product Detail (#340)

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -109,7 +109,10 @@ const router = createRouter({
   routes
 })
 
+let previousRoute: any = null;
+
 router.beforeEach((to, from) => {
+  previousRoute = from
   if (to.meta.permissionId && !hasPermission(to.meta.permissionId)) {
     let redirectToPath = from.path;
     // If the user has navigated from Login page or if it is page load, redirect user to settings page without showing any toast
@@ -120,5 +123,9 @@ router.beforeEach((to, from) => {
     }
   }
 })
+
+export function getPreviousRoute() {
+  return previousRoute
+}
 
 export default router

--- a/src/views/audit.vue
+++ b/src/views/audit.vue
@@ -114,6 +114,7 @@ import { mapGetters } from 'vuex';
 import { DateTime } from 'luxon';
 import { JobService } from '@/services/JobService';
 import { hasError } from '@/utils';
+import { getPreviousRoute } from '@/router';
 
 export default defineComponent({
   name: 'Audit',
@@ -170,6 +171,10 @@ export default defineComponent({
     })
   },
   async ionViewWillEnter() {
+    const previousRoute = this.getPreviousRoute()?.path || ''
+    if (!previousRoute.startsWith('/audit-product-details')) {
+      this.prodCatalogCategoryTypeId = '' // 'All' is selected by default
+    }
     this.isScrollingEnabled = false;
     await this.getCatalogProducts()
     await this.preparePreordBckordComputationJob()
@@ -298,6 +303,7 @@ export default defineComponent({
       productIdentificationPref,
       router,
       store,
+      getPreviousRoute
     };
   },
 });


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#340

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Fixed Inconsistent Page Landing on the Audit Tab When Switching Tabs After Viewing Preorder or Backorder Product Detail . added checks on the basis of previous route .

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/preorder#contribution-guideline)