### PR TITLE
refactor: use default split pane styling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -132,10 +132,6 @@ export default defineComponent({
 </script>
 <style scoped>
 
-ion-split-pane {
-  --side-width: 304px;
-}
-
 ion-item.selected {
   --color: var(--ion-color-secondary);
 }


### PR DESCRIPTION
## Summary
- remove custom styling overrides on the split pane so it follows Ionic defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f08a6b2958832186ec52e00d1f2bae